### PR TITLE
fix: Xcode 12 compatibility

### DIFF
--- a/ReactNativeIncallManager.podspec
+++ b/ReactNativeIncallManager.podspec
@@ -18,5 +18,5 @@ Pod::Spec.new do |s|
   s.preserve_paths         = 'LICENSE', 'package.json'
   s.source_files           = '**/*.{h,m}'
   s.exclude_files          = 'example/**/*'
-  s.dependency               'React'
+  s.dependency               'React-Core'
 end


### PR DESCRIPTION
Latest Xcode 12 fails to build while without a module to depend on `React-Core` directly hence this change is necessary for all native modules on iOS. For more details please check: [facebook/react-native#29633 (comment)](https://github.com/facebook/react-native/issues/29633#issuecomment-694187116)